### PR TITLE
fixed #66 check for sub-folders upon tractor initialization

### DIFF
--- a/server/cli/init/create-test-directory-structure.js
+++ b/server/cli/init/create-test-directory-structure.js
@@ -17,33 +17,32 @@ export default {
 };
 
 function createTestDirectoryStructure (testDirectory) {
-    return createRootDirectory(testDirectory)
-    .then(() => createSubDirectories(testDirectory))
-    .catch(TractorError, (error) => log.warn(`${error.message} Not creating folder structure...`));
-}
-
-function createRootDirectory (testDirectory) {
     log.info('Creating directory structure...');
-
-    return fs.mkdirAsync(testDirectory)
-    .catch(Promise.OperationalError, (error) => {
-        if (error && error.cause && error.cause.code === 'EEXIST') {
-            throw new TractorError(`"${testDirectory}" directory already exists.`);
-        } else {
-            throw error;
-        }
-    });
+    return createAllDirectories(testDirectory);
 }
 
-function createSubDirectories (testDirectory) {
+function createAllDirectories (testDirectory) {
     let createDirectories = [
+        '',
         constants.COMPONENTS,
         constants.FEATURES,
         constants.STEP_DEFINITIONS,
         constants.MOCK_DATA,
         constants.SUPPORT_DIR
-    ].map((directory) => fs.mkdirAsync(join(testDirectory, directory)));
-
+    ].map((directory) => createDir(join(testDirectory, directory))
+                        .catch(TractorError, (error) => log.warn(`${error.message} Not creating folder structure...`))
+    );
     return Promise.all(createDirectories)
     .then(() => log.verbose('Directory structure created.'));
+}
+
+function createDir (dir) {
+    return fs.mkdirAsync(dir)
+    .catch(Promise.OperationalError, (error) => {
+        if (error && error.cause && error.cause.code === 'EEXIST') {
+            throw new TractorError(`"${dir}" directory already exists.`);
+        } else {
+            throw error;
+        }
+    });
 }

--- a/server/cli/init/create-test-directory-structure.spec.js
+++ b/server/cli/init/create-test-directory-structure.spec.js
@@ -20,7 +20,7 @@ import path from 'path';
 import createTestDirectoryStructure from './create-test-directory-structure';
 
 describe('server/cli/init: create-test-directory-structure:', () => {
-    it('should create the root test directory', () => {
+    it('should create the tests directory structure', () => {
         sinon.stub(fs, 'mkdirAsync').returns(Promise.resolve());
         sinon.stub(log, 'info');
         sinon.stub(log, 'verbose');
@@ -29,6 +29,11 @@ describe('server/cli/init: create-test-directory-structure:', () => {
         return createTestDirectoryStructure.run('directory')
         .then(() => {
             expect(fs.mkdirAsync).to.have.been.calledWith('directory');
+            expect(fs.mkdirAsync).to.have.been.calledWith(path.join('directory', 'components'));
+            expect(fs.mkdirAsync).to.have.been.calledWith(path.join('directory', 'features'));
+            expect(fs.mkdirAsync).to.have.been.calledWith(path.join('directory', 'step-definitions'));
+            expect(fs.mkdirAsync).to.have.been.calledWith(path.join('directory', 'mock-data'));
+            expect(fs.mkdirAsync).to.have.been.calledWith(path.join('directory', 'support'));
         })
         .finally(() => {
             fs.mkdirAsync.restore();
@@ -38,7 +43,7 @@ describe('server/cli/init: create-test-directory-structure:', () => {
         });
     });
 
-    it('should tell the user if the root test directory already exists', () => {
+    it('should tell the user if the directory already exists', () => {
         let error = new Promise.OperationalError();
         error.cause = {
             code: 'EEXIST'
@@ -75,29 +80,7 @@ describe('server/cli/init: create-test-directory-structure:', () => {
         });
     });
 
-    it('should create the subdirectory structure', () => {
-        sinon.stub(fs, 'mkdirAsync').returns(Promise.resolve());
-        sinon.stub(log, 'info');
-        sinon.stub(log, 'verbose');
-        sinon.stub(log, 'warn');
-
-        return createTestDirectoryStructure.run('directory')
-        .then(() => {
-            expect(fs.mkdirAsync).to.have.been.calledWith(path.join('directory', 'components'));
-            expect(fs.mkdirAsync).to.have.been.calledWith(path.join('directory', 'features'));
-            expect(fs.mkdirAsync).to.have.been.calledWith(path.join('directory', 'step-definitions'));
-            expect(fs.mkdirAsync).to.have.been.calledWith(path.join('directory', 'mock-data'));
-            expect(fs.mkdirAsync).to.have.been.calledWith(path.join('directory', 'support'));
-        })
-        .finally(() => {
-            fs.mkdirAsync.restore();
-            log.info.restore();
-            log.verbose.restore();
-            log.warn.restore();
-        });
-    });
-
-    it('should tell the user  what it is doing', () => {
+    it('should tell the user what it is doing', () => {
         sinon.stub(fs, 'mkdirAsync').returns(Promise.resolve());
         sinon.stub(log, 'info');
         sinon.stub(log, 'verbose');


### PR DESCRIPTION
#66 missing sub-folders causes tractor failed.

updated  create-test-directory-structure.js and unit tests, all check exists and create sub-folders during tractor initialization.
