### PR TITLE
fix for Issue#105 

### DIFF
--- a/src/app/features/StepDefinitionEditor/Models/ExpectationModel.js
+++ b/src/app/features/StepDefinitionEditor/Models/ExpectationModel.js
@@ -74,7 +74,15 @@ var createExpectationModelConstructor = function (
         var expectationArguments = this.arguments.map(function (argument) {
             return argument.ast;
         });
-        var expectedResult = ast.literal(stringToLiteralService.toLiteral(this.value) || this.value);
+
+        if ( this.value.indexOf('\'') >= 0 || this.value.indexOf('"') >= 0  ){            
+             
+             var expectedResult = ast.literal(this.value.replace(/["']/g, ""));
+        } else {            
+             var stringtoLiteral = stringToLiteralService.toLiteral(this.value);
+
+             var expectedResult = ( (!!stringtoLiteral) ? ast.literal(stringtoLiteral) : ast.literal(this.value) );          
+        }
 
         return ast.template(template, {
             component: ast.identifier(this.component.variableName),

--- a/src/app/features/StepDefinitionEditor/Services/ExpectationParserService.js
+++ b/src/app/features/StepDefinitionEditor/Services/ExpectationParserService.js
@@ -19,7 +19,6 @@ var ExpectationParserService = function ExpectationParserService (
     function parse (step, ast) {
         try {
             var expectation = new ExpectationModel(step);
-            
             var expectationArgument = _.first(ast.arguments);
 
             expectation.value = ((typeof (expectationArgument.value) === "string") ? expectationArgument.raw : expectationArgument.value  )
@@ -30,7 +29,7 @@ var ExpectationParserService = function ExpectationParserService (
             expectation.action = parseAction(expectation, expectationCallExpression);
             expectation.condition = ast.callee.property.name;
             parseArguments(expectation, expectationCallExpression);
-            
+
             return expectation;
         } catch (e) {
             console.warn('Invalid expectation:', ast);

--- a/src/app/features/StepDefinitionEditor/Services/ExpectationParserService.js
+++ b/src/app/features/StepDefinitionEditor/Services/ExpectationParserService.js
@@ -19,7 +19,10 @@ var ExpectationParserService = function ExpectationParserService (
     function parse (step, ast) {
         try {
             var expectation = new ExpectationModel(step);
-            expectation.value = _.first(ast.arguments).value;
+            
+            var expectationArgument = _.first(ast.arguments);
+
+            expectation.value = ((typeof (expectationArgument.value) === "string") ? expectationArgument.raw : expectationArgument.value  )
 
             var expectationCallExpression = _.first(ast.callee.object.object.object.arguments);
 
@@ -27,7 +30,7 @@ var ExpectationParserService = function ExpectationParserService (
             expectation.action = parseAction(expectation, expectationCallExpression);
             expectation.condition = ast.callee.property.name;
             parseArguments(expectation, expectationCallExpression);
-
+            
             return expectation;
         } catch (e) {
             console.warn('Invalid expectation:', ast);


### PR DESCRIPTION
Problem - users are not able to use the boolean(false) in the expectations under step-def. So commonly used methods like isEnabled() when tested to.eventually.equal = false (usecase check button is disabled) was not working.

Analysis - Expectation model in line - ast.literal(stringToLiteralService.toLiteral(this.value) || this.value); When "this.value= false" , stringToLiteralService.toLiteral(this.value) will return boolean false and the above expression will be always falsify and "this.value" will be passed to ast.literal() , which will return string "false".

Changes - I want user to let tractor know what they are expecting- example boolean(false) or string(false). Because in many case the expression needs to be evaluated as string(false). And also because users should conceptually know what they are doing(whether they have to match boolean or string). 

Usage - So if they are expecting string they should use single/double quotes. And if they are expecting boolean then they should not use quotes. Number will be without quotes as usual and anything apart from string/boolean/number will get converted to string (this is an existing logic, haven't changed it).

Expectation Model has been changed to cater to above usage requirement.
Expectation ParserService has been changed so show string/boolean/Number as string/boolean/Number respectively on tractor.

the change has been tested. Please let know what you think.
