### PR TITLE
issue#96 UI changes for debugger option

### DIFF
--- a/e2e-tests/protractor.conf.js
+++ b/e2e-tests/protractor.conf.js
@@ -3,6 +3,7 @@ exports.config = {
     allScriptsTimeout: 11000,
     specs: ['features/**/*.feature'],
     capabilities: { 'browserName': 'chrome' },
+    params: { debug: false },
     framework: 'cucumber',
     cucumberOpts: {
         require: [

--- a/e2e-tests/support/hooks.js
+++ b/e2e-tests/support/hooks.js
@@ -3,8 +3,6 @@
 /* eslint-disable no-var, prefer-arrow-callback */
 var cucumber = require('cucumber');
 var cucumberHtmlReport = require('cucumber-html-report');
-var log = require('npmlog');
-var moment = require('moment');
 var path = require('path');
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
@@ -27,7 +25,7 @@ function createReporter () {
         })
          /* eslint-disable prefer-template */
         .catch(function (error) {
-            log.error('Failed to save test results to json file. ' + error);
+            console.log('Failed to save test results to json file. ' + error);
         });
     }
 
@@ -42,9 +40,8 @@ function createReporter () {
     }
 
     function getFileName (file, extension) {
-        var reportTimestamp = moment().format('YYYY-MM-DD_HH-mm-ss');
         /* eslint-disable prefer-template */
-        return file + reportTimestamp + '.' + extension;
+        return file + new Date().toLocaleString().replace(/[\/\\:]/g, "-") + '.' + extension;
     }
 }
 

--- a/e2e-tests/support/world.js
+++ b/e2e-tests/support/world.js
@@ -1,12 +1,12 @@
 'use strict';
 
+/* eslint-disable no-var, prefer-arrow-callback */
 var HttpBackend = require('httpbackend');
 
 var CustomWorld = (function () {
     var chai = require('chai');
     var chaiAsPromised = require('chai-as-promised');
     var CustomWorld = function CustomWorld () {
-        //global.browser = global.protractor = require('protractor').getInstance();
         global.By = global.protractor.By;
         chai.use(chaiAsPromised);
         global.expect = chai.expect;
@@ -17,25 +17,76 @@ var CustomWorld = (function () {
 })();
 
 module.exports = function () {
-    this.setDefaultTimeout(60 * 1000);
-
     this.World = function (callback) {
         var w = new CustomWorld();
         return callback(w);
     };
 
     /* eslint-disable new-cap */
-    this.Before(function (scenario, callback) {
+    this.Before(function (scenario, callback) {       
     /* eslint-enable new-cap */
         global.httpBackend = new HttpBackend(global.browser);
         callback();
     });
 
     /* eslint-disable new-cap */
-    this.After(function(scenario, callback) {
+    this.StepResult(function (event, callback) {
+        var stepResult = event.getPayloadItem('stepResult');
+        if (stepResult.isFailed() && global.browser.params.debug === 'true') {
+            global.browser.pause();
+        }
+        callback();
+    });
+
+    /* eslint-disable new-cap */
+    this.After(function (scenario, callback) {
     /* eslint-enable new-cap */
         global.httpBackend.clear();
-        callback();
+        global.browser.manage().deleteAllCookies();
+        global.browser.executeScript('window.sessionStorage.clear();');
+        global.browser.executeScript('window.localStorage.clear();');
+
+        if (scenario.isFailed()) {
+            Promise.all([takeScreenshot(scenario), printBrowserLog()])
+            .then(function () {
+                callback();
+            })
+            .catch(function (err) {
+                callback(err)
+            });
+        } else {
+            callback();
+        }
+
+        function takeScreenshot (scenario) {
+            return global.browser.takeScreenshot()
+            .then(function (base64png) {
+                var decodedImage = new Buffer(base64png, 'base64').toString('binary');
+                scenario.attach(decodedImage, 'image/png');
+            });
+        }
+
+        function printBrowserLog () {
+            return global.browser.manage().logs().get('browser')
+            .then(function (browserLog) {
+                var severeErrors = browserLog.filter(function (log) {
+                    return log.level.name === 'SEVERE';
+                })
+                .map(function (log) {
+                    return log.message.substring(log.message.indexOf('Error'), log.message.indexOf('\n'));
+                });
+
+                var uniqueErrors = {};
+                if (severeErrors) {
+                    severeErrors.forEach(function (message) {
+                        uniqueErrors[message] = true;
+                    });
+                    Object.keys(uniqueErrors).map(function (message) {
+                        console.error(message);
+                    });
+                }
+            });
+        }
     });
 
     return this.World;

--- a/server/cli/init/base-file-sources/hooks.js
+++ b/server/cli/init/base-file-sources/hooks.js
@@ -3,7 +3,6 @@
 /* eslint-disable no-var, prefer-arrow-callback */
 var cucumber = require('cucumber');
 var cucumberHtmlReport = require('cucumber-html-report');
-var log = require('npmlog');
 var path = require('path');
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
@@ -26,7 +25,7 @@ function createReporter () {
         })
          /* eslint-disable prefer-template */
         .catch(function (error) {
-            log.error('Failed to save test results to json file. ' + error);
+            console.log('Failed to save test results to json file. ' + error);
         });
     }
 
@@ -42,7 +41,7 @@ function createReporter () {
 
     function getFileName (file, extension) {
         /* eslint-disable prefer-template */
-        return file + new Date().toLocaleString().replace(/[\/\\:]/g,"-") + '.' + extension;
+        return file + new Date().toLocaleString().replace(/[\/\\:]/g, "-") + '.' + extension;
     }
 }
 

--- a/server/cli/init/base-file-sources/protractor.conf.js
+++ b/server/cli/init/base-file-sources/protractor.conf.js
@@ -11,6 +11,10 @@ exports.config = {
         browserName: 'chrome'
     },
 
+    params: {
+        debug: false
+    },
+
     directConnect: true,
 
     framework: 'cucumber',

--- a/server/cli/init/base-file-sources/world.js
+++ b/server/cli/init/base-file-sources/world.js
@@ -22,31 +22,18 @@ module.exports = function () {
         return callback(w);
     };
 
-    // TODO: Get rid of `singleFeature` here. It works ok,
-    // but I’d rather see if there’s a way to get the number of
-    // specs from within the `StepResult` hook…
-    var singleFeature = false;
     /* eslint-disable new-cap */
-    this.Before(function (scenario, callback) {
+    this.Before(function (scenario, callback) {       
     /* eslint-enable new-cap */
         global.httpBackend = new HttpBackend(global.browser);
-        global.browser.getProcessedConfig()
-        .then(function (value) {
-            if (value.specs.length === 1) {
-                singleFeature = true;
-            }
-            callback();
-        });
+        callback();
     });
 
     /* eslint-disable new-cap */
     this.StepResult(function (event, callback) {
-        var stepResult;
-        if (singleFeature) {
-            stepResult = event.getPayloadItem('stepResult');
-            if (stepResult.isFailed()) {
-                global.browser.pause();
-            }
+        var stepResult = event.getPayloadItem('stepResult');
+        if (stepResult.isFailed() && global.browser.params.debug === 'true') {
+            global.browser.pause();
         }
         callback();
     });

--- a/server/cli/init/create-test-directory-structure.js
+++ b/server/cli/init/create-test-directory-structure.js
@@ -23,6 +23,7 @@ function createTestDirectoryStructure (testDirectory) {
 
 function createAllDirectories (testDirectory) {
     let createDirectories = [
+        /* eslint-disable no-warning-comments */
         // TODO: This is a bit cryptic, pull this out into another promise
         // that creates the root dir, and do that first. Otherwise there
         // may be a race condition here?

--- a/server/sockets/protractor-runner.js
+++ b/server/sockets/protractor-runner.js
@@ -62,22 +62,16 @@ function startProtractor (socket, runOptions) {
         return deferred;
     }
 
-    // TODO: This looks a bit funky still, I’m not sure what it’s doing,
-    // but it looks too complicated.
     if (runOptions.hasOwnProperty("feature")) {
-        if (_.isUndefined(runOptions.feature)) {
-            reject(new TractorError('to run a single feature, `feature` must be defined.'));
-            return deferred;
-        } else {
-            featureToRun = join(config.testDirectory, '/features', '/**/', `${runOptions.feature}.feature`);
-        }
+        featureToRun = join('/features', '/**/', `${runOptions.feature}.feature`);
     } else {
-        featureToRun = join(config.testDirectory, '/features/**/*.feature');
+        featureToRun = '/features/**/*.feature';
+        runOptions.debug = false;
     }
 
-    let specs = featureToRun;
+    let specs = join(config.testDirectory, featureToRun);
 
-    let protractor = spawn('node', [PROTRACTOR_PATH, E2E_PATH, '--baseUrl', runOptions.baseUrl, '--specs', specs]);
+    let protractor = spawn('node', [PROTRACTOR_PATH, E2E_PATH, '--baseUrl', runOptions.baseUrl, '--specs', specs, '--params.debug', runOptions.debug]);
 
     protractor.stdout.on('data', sendDataToClient.bind(socket));
     protractor.stderr.on('data', sendErrorToClient.bind(socket));

--- a/server/sockets/protractor-runner.spec.js
+++ b/server/sockets/protractor-runner.spec.js
@@ -43,6 +43,8 @@ describe('server/sockets: protractor-runner:', () => {
             baseUrl: "baseUrl"
         };
 
+        runOptions.debug = false;
+
         sinon.stub(childProcess, 'spawn').returns(spawnEmitter);
         sinon.stub(config, 'beforeProtractor');
         sinon.stub(config, 'afterProtractor');
@@ -57,7 +59,7 @@ describe('server/sockets: protractor-runner:', () => {
         return run.then(() => {
             let protractorPath = path.join('node_modules', 'protractor', 'bin', 'protractor');
             let protractorConfPath = path.join('e2e-tests', 'protractor.conf.js');
-            expect(childProcess.spawn).to.have.been.calledWith('node', [protractorPath, protractorConfPath, '--baseUrl', 'baseUrl', '--specs', specs]);
+            expect(childProcess.spawn).to.have.been.calledWith('node', [protractorPath, protractorConfPath, '--baseUrl', 'baseUrl', '--specs', specs, '--params.debug', runOptions.debug]);
         })
         .finally(() => {
             childProcess.spawn.restore();
@@ -80,7 +82,8 @@ describe('server/sockets: protractor-runner:', () => {
 
         let runOptions = {
             baseUrl: "baseUrl",
-            feature: "feature"
+            feature: "feature",
+            debug: true
         };
 
         let specs = path.join(config.testDirectory, '/features/**/feature.feature');
@@ -99,7 +102,7 @@ describe('server/sockets: protractor-runner:', () => {
         return run.then(() => {
             let protractorPath = path.join('node_modules', 'protractor', 'bin', 'protractor');
             let protractorConfPath = path.join('e2e-tests', 'protractor.conf.js');
-            expect(childProcess.spawn).to.have.been.calledWith('node', [protractorPath, protractorConfPath, '--baseUrl', 'baseUrl', '--specs', specs]);
+            expect(childProcess.spawn).to.have.been.calledWith('node', [protractorPath, protractorConfPath, '--baseUrl', 'baseUrl', '--specs', specs, '--params.debug', runOptions.debug]);
         })
         .finally(() => {
             childProcess.spawn.restore();
@@ -124,33 +127,6 @@ describe('server/sockets: protractor-runner:', () => {
         return protractorRunner.run(socket, runOptions)
         .then(() => {
             expect(log.error).to.have.been.calledWith('`baseUrl` must be defined.');
-        })
-        .finally(() => {
-            config.beforeProtractor.restore();
-            config.afterProtractor.restore();
-            log.error.restore();
-            log.info.restore();
-        });
-    });
-
-    it('should throw an `Error` on single feature run, if `feature` is not defined:', () => {
-        let feature;
-        let runOptions = {
-            baseUrl: "baseUrl",
-            feature
-        };
-        let socket = {
-            disconnect: _.noop
-        };
-
-        sinon.stub(config, 'beforeProtractor');
-        sinon.stub(config, 'afterProtractor');
-        sinon.stub(log, 'error');
-        sinon.stub(log, 'info');
-
-        return protractorRunner.run(socket, runOptions)
-        .then(() => {
-            expect(log.error).to.have.been.calledWith('to run a single feature, `feature` must be defined.');
         })
         .finally(() => {
             config.beforeProtractor.restore();

--- a/src/app/features/FeatureEditor/FeatureEditor.html
+++ b/src/app/features/FeatureEditor/FeatureEditor.html
@@ -14,11 +14,16 @@
                     example="Feature"
                     validate-file-name>
                 </tractor-text-input>
-            </div>
+            </div>             
             <div class="file-options__file-actions">
                 <tractor-confirm-dialog trigger="featureEditor.confirmOverWrite">
                     <p>This will overwrite "{{ featureEditor.fileModel.name }}". Continue?</p>
                 </tractor-confirm-dialog>
+                <tractor-checkbox ng-show="featureEditor.fileModel.name"
+                     class="file-options__save-file"
+                     label="debug"
+                     model="featureEditor">
+                </tractor-checkbox>
                  <tractor-action ng-show="featureEditor.fileModel.name"
                       class="file-options__save-file"
                       action="Run feature"

--- a/src/app/features/FeatureEditor/FeatureEditorController.js
+++ b/src/app/features/FeatureEditor/FeatureEditorController.js
@@ -39,14 +39,17 @@ var FeatureEditorController = function FeatureEditorController (
     );
 
     this.runnerService = runnerService;
+    controller.debug = false;
+    this.controller = controller;
     controller.runFeature = runFeature.bind(this);    
     return controller;
 };
 
-function runFeature (toRun) {  
+function runFeature (toRun) {      
     if (toRun){
-        this.runnerService.runProtractor({           
-            feature: toRun
+        this.runnerService.runProtractor({
+            feature: toRun,
+            debug: this.controller.debug
         });
     }
 }

--- a/src/styles/_file-options.scss
+++ b/src/styles/_file-options.scss
@@ -1,6 +1,6 @@
 .file-options {
     font-size: 0;
-    height: 10%;
+    height: 11%;
     background: rgba(225, 225, 225, 1);
 }
 


### PR DESCRIPTION
Problem Statement - User wanted to opt to have the test run in debug mode or not.Currently tractor takes that call and places the protractor in debug mode. User wanted this feature because on failure they want to interact with the paused browser.

Changes - Checkbox in the feature page will allow the user to opt for to run feature in the debug mode. Protractor will not pause when entire project is triggered event though test case fails.

the changes has been tested.

Please let me know what you think.

![image](https://cloud.githubusercontent.com/assets/9716232/19371926/bf13d07e-9213-11e6-9ad0-19ea212a80c5.png)
