### PR TITLE
setting height on header cuts off the navs

### DIFF
--- a/packages/ui/src/styles/style.scss
+++ b/packages/ui/src/styles/style.scss
@@ -31,10 +31,6 @@ body div[ui-view], main {
     width: 100%;
 }
 
-header {
-    height: 13.5%
-}
-
 main {
     height: 86.5%;
 }


### PR DESCRIPTION
Have started to use tractor recently. Setting a height on the header so the nav gets cut of is the first and most annoying of the many UI crimes in tractor