### PR TITLE
replace empty object with empty string on request body

### DIFF
--- a/plugins/mock-requests/src/protractor/server.js
+++ b/plugins/mock-requests/src/protractor/server.js
@@ -42,7 +42,8 @@ export async function serve (baseUrl, mockRequestsConfig) {
 
     application.use(proxy(host, {
         proxyReqOptDecorator: createRequestDecorator(host, mockRequestsConfig),
-        userResDecorator: createResponseDecorator(host)
+        userResDecorator: createResponseDecorator(host),
+        proxyReqBodyDecorator: createRequestBodyDecorator()
     }));
 
     return new Promise(resolve => {
@@ -106,6 +107,18 @@ function createResponseDecorator (host) {
             }
         }
         return result;
+    };
+}
+
+function createRequestBodyDecorator () { 
+    return function (body) {
+        // Get requests are being sent with a body of an empty object 
+        // This causes GCP load balancer to throw a 400 error
+        // In this situation replace with an empty string
+        const bodyIsEmptyObject = typeof body === 'object' && Object.keys(body).length === 0;
+        if (bodyIsEmptyObject) {
+            return '';
+        }
     };
 }
 


### PR DESCRIPTION
This PR allows the Tractor mock request proxy to work when the underlying backend is GCP.

GET requests to the GCP load balancer throw a 400 when they have a body.

This PR replaces an empty object with an empty string in the express http proxy decorator. 

More info here: https://issuetracker.google.com/issues/36886282